### PR TITLE
Map new Context contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # appwrite-test-utils
 Classes to help you writing your PHPUnit tests for Appwrite functions
 
-### Why a package with a single interface?
-Personal needs that may be useful for somebody else XD
+### Why a package only with contracts?
+Personal needs that may be useful to someone else XD
 
 Basically if you try to write a test to check the data sent to the **json** or **send** methods of Appwrite Functions' API like below:
 

--- a/src/Context.php
+++ b/src/Context.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SSAWeb\AppwriteTestUtils;
+
+abstract class Context {
+    public Response $res;
+    public Request $req;
+    public abstract function log(string $message): void;
+    public abstract function error(string $message): void;
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SSAWeb\AppwriteTestUtils;
+
+abstract class Request {
+    public string $bodyRaw;
+    public string | object $body;
+    public array $headers;
+    public string $scheme;
+    public string $method;
+    public string $url;
+    public string $host;
+    public string $port;
+    public string $path;
+    public string $queryString;
+    public object $query;
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -3,6 +3,8 @@
 namespace SSAWeb\AppwriteTestUtils;
 
 interface Response {
-    public function send(string $text, int $status);
-    public function json(array $obj, int $status);
+    public function empty(): void;
+    public function redirect(string $text, int $status): void;
+    public function send(string $text, int $status): void;
+    public function json(array $obj, int $status): void;
 }


### PR DESCRIPTION
Due to the release of appwrite v1.4 we need to map the new context contract to be able to cover it in our tests.